### PR TITLE
Pass duckCount from MainActivity to result screens via Intent.

### DIFF
--- a/app/src/main/java/com/example/duckrace/BetResultLoseActivity.java
+++ b/app/src/main/java/com/example/duckrace/BetResultLoseActivity.java
@@ -23,7 +23,7 @@ public class BetResultLoseActivity extends AppCompatActivity {
     private LinearLayout duckRankingContainer;
     private LinearLayout leftColumn;
     private LinearLayout rightColumn;
-    private TextView tvDefeat, tvTotalLoss;
+    private TextView tvDefeat, tvTotalLoss, tvNoBetMessage;
     private Button btnContinue;
 
     private List<DuckResult> duckResults = new ArrayList<>();
@@ -66,6 +66,7 @@ public class BetResultLoseActivity extends AppCompatActivity {
         leftColumn = findViewById(R.id.leftColumn);
         rightColumn = findViewById(R.id.rightColumn);
         btnContinue = findViewById(R.id.btnContinue);
+        tvNoBetMessage = findViewById(R.id.tvNoBetMessage);
 
         btnContinue.setOnClickListener(v -> {
             finish();
@@ -78,8 +79,8 @@ public class BetResultLoseActivity extends AppCompatActivity {
         int[] duckIcons = { R.drawable.duck_run, R.drawable.duck_run, R.drawable.duck_run,
                 R.drawable.duck_run, R.drawable.duck_run, R.drawable.duck_run };
 
-        // Show up to 5 ducks (1-3 left, 4-5 right)
-        int maxDucks = Math.min(duckNames.length, 5);
+        // Show up to actual race duck count
+        int maxDucks = Math.min(duckNames.length, getIntent().getIntExtra("duckCount", 5));
         for (int i = 0; i < maxDucks; i++) {
             DuckResult result = new DuckResult();
             result.name = duckNames[i];
@@ -120,12 +121,29 @@ public class BetResultLoseActivity extends AppCompatActivity {
         tvDefeat.setText("You lose the bet.");
         tvTotalLoss.setText("Tổng thua: -" + lossAmount + " xu");
 
-        // Create duck ranking rows: 1-3 on left, 4-6 on right
-        for (int i = 0; i < duckResults.size(); i++) {
-            DuckResult result = duckResults.get(i);
-            LinearLayout parent = (i < 3) ? leftColumn : rightColumn;
-            View rowView = createDuckRow(result, i + 1, parent);
-            parent.addView(rowView);
+        boolean hasAnyBet = false;
+        if (userBets != null) {
+            for (Bet b : userBets) {
+                if (b != null && b.amount > 0) { hasAnyBet = true; break; }
+            }
+        }
+
+        if (!hasAnyBet) {
+            duckRankingContainer.setVisibility(View.GONE);
+            if (tvNoBetMessage != null) {
+                tvNoBetMessage.setVisibility(View.VISIBLE);
+                tvNoBetMessage.setText("You didn't place any bet.");
+            }
+        } else {
+            if (tvNoBetMessage != null) tvNoBetMessage.setVisibility(View.GONE);
+            duckRankingContainer.setVisibility(View.VISIBLE);
+            // Create duck ranking rows: 1-3 on left, remaining on right
+            for (int i = 0; i < duckResults.size(); i++) {
+                DuckResult result = duckResults.get(i);
+                LinearLayout parent = (i < 3) ? leftColumn : rightColumn;
+                View rowView = createDuckRow(result, i + 1, parent);
+                parent.addView(rowView);
+            }
         }
     }
 

--- a/app/src/main/java/com/example/duckrace/BetResultWinActivity.java
+++ b/app/src/main/java/com/example/duckrace/BetResultWinActivity.java
@@ -24,7 +24,7 @@ public class BetResultWinActivity extends AppCompatActivity {
     private LinearLayout duckRankingContainer;
     private LinearLayout leftColumn;
     private LinearLayout rightColumn;
-    private TextView tvVictory, tvTotalWin;
+    private TextView tvVictory, tvTotalWin, tvNoBetMessage;
     private Button btnContinue;
 
     private List<DuckResult> duckResults = new ArrayList<>();
@@ -67,6 +67,7 @@ public class BetResultWinActivity extends AppCompatActivity {
         leftColumn = findViewById(R.id.leftColumn);
         rightColumn = findViewById(R.id.rightColumn);
         btnContinue = findViewById(R.id.btnContinue);
+        tvNoBetMessage = findViewById(R.id.tvNoBetMessage);
 
         btnContinue.setOnClickListener(v -> {
             finish();
@@ -79,8 +80,8 @@ public class BetResultWinActivity extends AppCompatActivity {
         int[] duckIcons = { R.drawable.duck_run, R.drawable.duck_run, R.drawable.duck_run,
                 R.drawable.duck_run, R.drawable.duck_run, R.drawable.duck_run };
 
-        // Show up to 5 ducks (1-3 left, 4-5 right)
-        int maxDucks = Math.min(duckNames.length, 5);
+        // Show up to actual race duck count
+        int maxDucks = Math.min(duckNames.length, getIntent().getIntExtra("duckCount", 5));
         for (int i = 0; i < maxDucks; i++) {
             DuckResult result = new DuckResult();
             result.name = duckNames[i];
@@ -121,12 +122,29 @@ public class BetResultWinActivity extends AppCompatActivity {
         tvVictory.setText("You won the bet.");
         tvTotalWin.setText("Tổng thắng: +" + winAmount + " xu");
 
-        // Create duck ranking rows: 1-3 on left, 4-6 on right
-        for (int i = 0; i < duckResults.size(); i++) {
-            DuckResult result = duckResults.get(i);
-            LinearLayout parent = (i < 3) ? leftColumn : rightColumn;
-            View rowView = createDuckRow(result, i + 1, parent);
-            parent.addView(rowView);
+        boolean hasAnyBet = false;
+        if (userBets != null) {
+            for (Bet b : userBets) {
+                if (b != null && b.amount > 0) { hasAnyBet = true; break; }
+            }
+        }
+
+        if (!hasAnyBet) {
+            duckRankingContainer.setVisibility(View.GONE);
+            if (tvNoBetMessage != null) {
+                tvNoBetMessage.setVisibility(View.VISIBLE);
+                tvNoBetMessage.setText("You didn't place any bet.");
+            }
+        } else {
+            if (tvNoBetMessage != null) tvNoBetMessage.setVisibility(View.GONE);
+            duckRankingContainer.setVisibility(View.VISIBLE);
+            // Create duck ranking rows: 1-3 on left, remaining on right
+            for (int i = 0; i < duckResults.size(); i++) {
+                DuckResult result = duckResults.get(i);
+                LinearLayout parent = (i < 3) ? leftColumn : rightColumn;
+                View rowView = createDuckRow(result, i + 1, parent);
+                parent.addView(rowView);
+            }
         }
     }
 

--- a/app/src/main/java/com/example/duckrace/MainActivity.java
+++ b/app/src/main/java/com/example/duckrace/MainActivity.java
@@ -531,6 +531,7 @@ public class MainActivity extends AppCompatActivity {
                             intent.putExtra("amount", finalTotalWin);
                             intent.putExtra("duck", winnerName);
                             intent.putExtra("betData", betDataString);
+                            intent.putExtra("duckCount", duckCount);
                             startActivity(intent);
                         });
             } else {
@@ -538,6 +539,7 @@ public class MainActivity extends AppCompatActivity {
                 intent.putExtra("amount", totalBet);
                 intent.putExtra("duck", winnerName);
                 intent.putExtra("betData", betDataString);
+                intent.putExtra("duckCount", duckCount);
                 startActivity(intent);
             }
         } else {
@@ -545,6 +547,7 @@ public class MainActivity extends AppCompatActivity {
             intent.putExtra("amount", 0);
             intent.putExtra("duck", winnerName);
             intent.putExtra("betData", betDataString);
+            intent.putExtra("duckCount", runners.size());
             startActivity(intent);
         }
 

--- a/app/src/main/res/layout/activity_bet_result_lose.xml
+++ b/app/src/main/res/layout/activity_bet_result_lose.xml
@@ -41,6 +41,19 @@
         android:textSize="24sp"
         android:textStyle="bold" />
 
+    <!-- Message when user placed no bets -->
+    <TextView
+        android:id="@+id/tvNoBetMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/tvTotalLoss"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="8dp"
+        android:text="You didn't place any bet."
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:visibility="gone" />
+
     <!-- Duck Ranking Container: two columns (left 3, right 3) -->
     <LinearLayout
         android:id="@+id/duckRankingContainer"

--- a/app/src/main/res/layout/activity_bet_result_win.xml
+++ b/app/src/main/res/layout/activity_bet_result_win.xml
@@ -41,6 +41,19 @@
         android:textSize="24sp"
         android:textStyle="bold" />
 
+    <!-- Message when user placed no bets -->
+    <TextView
+        android:id="@+id/tvNoBetMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/tvTotalWin"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="8dp"
+        android:text="You didn't place any bet."
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:visibility="gone" />
+
     <!-- Duck Ranking Container: two columns (left 3, right 3) -->
     <LinearLayout
         android:id="@+id/duckRankingContainer"

--- a/app/src/main/res/layout/item_duck_result.xml
+++ b/app/src/main/res/layout/item_duck_result.xml
@@ -35,10 +35,11 @@
         android:id="@+id/mvpBadge"
         android:layout_width="40dp"
         android:layout_height="20dp"
-        android:layout_alignStart="@id/imgDuck"
-        android:layout_alignBottom="@id/imgDuck"
-        android:layout_marginStart="5dp"
-        android:layout_marginBottom="5dp"
+        android:layout_toEndOf="@id/tvDuckRank"
+        android:layout_toStartOf="@id/imgDuck"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:background="@drawable/mvp_badge_background"
         android:visibility="gone">
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.3"
+agp = "8.13.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"


### PR DESCRIPTION
Use duckCount to limit leaderboard items instead of hard-coded 5 in win/lose activities. Move MVP badge between rank and duck icon to avoid overlay. Add tvNoBetMessage and logic to show “You didn't place any bet.” and hide leaderboard when no bets were placed.